### PR TITLE
serverpacks - add option to override bind address for http server

### DIFF
--- a/mods/serverpacks.disabled
+++ b/mods/serverpacks.disabled
@@ -10,3 +10,6 @@ classpath=serverpacks.jar
 # By default the serverPort or the automaticly choosen port will be used
 # This setting may be required when doing port forwarding in the router
 #publicServerPort=
+# Sets a different address for the HTTP server to bind to. Can be 0.0.0.0 to
+# bind to all interfaces. Default is external ip in server settings.
+#internalServerAddress=

--- a/src/mods/serverpacks/org/gotti/wurmunlimited/mods/serverpacks/PackServer.java
+++ b/src/mods/serverpacks/org/gotti/wurmunlimited/mods/serverpacks/PackServer.java
@@ -26,12 +26,17 @@ public abstract class PackServer {
 	private final String publicServerAddress;
 	private final int publicServerPort;
 	
-	public PackServer(int port, String publicServerAddress, int publicServerPort) throws IOException {
+	public PackServer(int port, String publicServerAddress, int publicServerPort, String internalServerAddress) throws IOException {
 		
 		this.publicServerAddress = publicServerAddress;
 		this.publicServerPort = publicServerPort;
-		
-		InetAddress addr = InetAddress.getByAddress(Server.getInstance().getExternalIp());
+
+		InetAddress addr;
+		if (internalServerAddress == null)
+			addr = InetAddress.getByAddress(Server.getInstance().getExternalIp());
+		else
+			addr = InetAddress.getByName(internalServerAddress);
+
 		InetSocketAddress address = new InetSocketAddress(addr, port);
 		httpServer = HttpServer.create(address, 0);
 		httpServer.createContext("/packs/", new HttpHandler() {

--- a/src/mods/serverpacks/org/gotti/wurmunlimited/mods/serverpacks/ServerPackMod.java
+++ b/src/mods/serverpacks/org/gotti/wurmunlimited/mods/serverpacks/ServerPackMod.java
@@ -34,6 +34,7 @@ public class ServerPackMod implements WurmMod, ModListener, Initable, PlayerLogi
 
 	private int serverPort = 0;
 	private String publicServerAddress = null;
+	private String internalServerAddress = null;
 	private int publicServerPort = 0;
 
 	private PackServer packServer;
@@ -47,10 +48,12 @@ public class ServerPackMod implements WurmMod, ModListener, Initable, PlayerLogi
 		this.serverPort = Integer.parseInt(properties.getProperty("serverPort", Integer.toString(serverPort)));
 		this.publicServerPort = Integer.parseInt(properties.getProperty("publicServerPort", Integer.toString(publicServerPort)));
 		this.publicServerAddress = properties.getProperty("publicServerAddress");
+		this.internalServerAddress = properties.getProperty("internalServerAddress");
 
 		logger.info("serverPort: " + serverPort);
 		logger.info("publicServerAddress: " + publicServerAddress);
 		logger.info("publicServerPort: " + publicServerPort);
+		logger.info("internalServerAddress: " + internalServerAddress);
 	}
 
 	@Override
@@ -131,7 +134,7 @@ public class ServerPackMod implements WurmMod, ModListener, Initable, PlayerLogi
 	@Override
 	public void onServerStarted() {
 		try {
-			packServer = new PackServer(serverPort, publicServerAddress, publicServerPort) {
+			packServer = new PackServer(serverPort, publicServerAddress, publicServerPort, internalServerAddress) {
 
 				@Override
 				protected InputStream getPackStream(String packid) throws IOException {


### PR DESCRIPTION
I'm running a somewhat... exotic network setup and need to have the HTTP server in serverpacks mod listen on something that isn't wurm server external IP. 

I've added an option to set the bind address, with the current behavior remaining as default.