### PR TITLE
Add mod communication system

### DIFF
--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/Channel.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/Channel.java
@@ -1,0 +1,55 @@
+package org.gotti.wurmunlimited.modcomm;
+
+import com.wurmonline.communication.SocketConnection;
+import com.wurmonline.server.players.Player;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Channel object, created by calling {@link ModComm#registerChannel}
+ */
+public class Channel {
+    final int id;
+    final IChannelListener listener;
+    final String name;
+
+    Channel(int id, String name, IChannelListener listener) {
+        this.id = id;
+        this.name = name;
+        this.listener = listener;
+    }
+
+    /**
+     * Send message to a player on this channel. Channel must be active for that player.
+     *
+     * @param player  player object
+     * @param message contents of the message
+     */
+    public void sendMessage(Player player, ByteBuffer message) {
+        if (!isActiveForPlayer(player))
+            throw new RuntimeException(String.format("Channel %s is not active for player %s", name, player.getName()));
+        try {
+            SocketConnection conn = player.getCommunicator().getConnection();
+            ByteBuffer buff = conn.getBuffer();
+            buff.put(ModCommConstants.CMD_MODCOMM);
+            buff.put(ModCommConstants.PACKET_MESSAGE);
+            buff.putInt(id);
+            buff.put(message);
+            buff.put(message);
+            conn.flush();
+        } catch (Exception e) {
+            ModComm.logException(String.format("Error sending packet on channel %s to player %s", name, player.getName()), e);
+        }
+    }
+
+    /**
+     * Check if a channel is active for a specific player.
+     *
+     * @param player player object
+     * @return true if the channel is active
+     */
+    public boolean isActiveForPlayer(Player player) {
+        PlayerModConnection conn = ModComm.getPlayerConnection(player);
+        return conn.isActive() && conn.getChannels().contains(this);
+    }
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/IChannelListener.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/IChannelListener.java
@@ -1,0 +1,28 @@
+package org.gotti.wurmunlimited.modcomm;
+
+import com.wurmonline.server.players.Player;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Listener for mod channels, implement in a class and register with {@link ModComm#registerChannel}
+ */
+public interface IChannelListener {
+    /**
+     * Handle a message from a player
+     *
+     * @param player  player object
+     * @param message message contents
+     */
+    default void handleMessage(Player player, ByteBuffer message) {
+    }
+
+    /**
+     * Called when a player is connected and this channel is activated
+     *
+     * @param player player object
+     */
+    default void onPlayerConnected(Player player) {
+    }
+
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/ModComm.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/ModComm.java
@@ -1,0 +1,123 @@
+package org.gotti.wurmunlimited.modcomm;
+
+import com.wurmonline.server.players.Player;
+import javassist.*;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+import org.gotti.wurmunlimited.modloader.classhooks.HookManager;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ModComm {
+    static final HashMap<String, Channel> channels = new HashMap<>();
+    static final HashMap<Integer, Channel> idMap = new HashMap<>();
+
+    private static int nextChannelId = 1;
+
+    private static Field fPlayerConnection;
+
+    private static final Logger logger = Logger.getLogger("ModComm");
+
+    /**
+     * Register mod channel
+     *
+     * @param name     Unique identifier of the channel
+     * @param listener Listener that will handle communication
+     * @return new channel object
+     */
+    public static Channel registerChannel(String name, IChannelListener listener) {
+        if (channels.containsKey(name))
+            throw new RuntimeException(String.format("Channel %s already registered", name));
+        Channel ch = new Channel(nextChannelId++, name, listener);
+        idMap.put(ch.id, ch);
+        channels.put(name, ch);
+        return ch;
+    }
+
+    // === internal stuff ===
+
+    /**
+     * Get player connection state
+     */
+    @SuppressWarnings("unchecked")
+    static PlayerModConnection getPlayerConnection(Player player) {
+        try {
+            return (PlayerModConnection) fPlayerConnection.get(player);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Internal initialization, called from {@link org.gotti.wurmunlimited.modloader.ModLoader#loadModsFromModDir}
+     */
+    public static void init() {
+        final ClassPool classPool = HookManager.getInstance().getClassPool();
+        try {
+            CtClass ctPlayer = classPool.getCtClass("com.wurmonline.server.players.Player");
+
+            CtField fConnection = new CtField(classPool.get("org.gotti.wurmunlimited.modcomm.PlayerModConnection"), "modConnection", ctPlayer);
+            fConnection.setModifiers(Modifier.PUBLIC);
+            ctPlayer.addField(fConnection, "new org.gotti.wurmunlimited.modcomm.PlayerModConnection()");
+
+            CtClass ctCommunicator = classPool.getCtClass("com.wurmonline.server.creatures.Communicator");
+            ctCommunicator.getMethod("reallyHandle", "(ILjava/nio/ByteBuffer;)V").instrument(new ExprEditor() {
+                private boolean first = true;
+
+                @Override
+                public void edit(MethodCall m) throws CannotCompileException {
+                    if (m.getMethodName().equals("get") && first) {
+                        m.replace("$_ = $proceed($$);" +
+                                "if ($_ == " + ModCommConstants.CMD_MODCOMM + ") {" +
+                                "   org.gotti.wurmunlimited.modcomm.ModCommHandler.handlePacket(player, byteBuffer);" +
+                                "   return;" +
+                                "}");
+                        first = false;
+                    }
+                }
+            });
+        } catch (NotFoundException | CannotCompileException e) {
+            throw new RuntimeException("Error initializing ModComm", e);
+        }
+    }
+
+    /**
+     * Internal late initialization, called from {@link org.gotti.wurmunlimited.modloader.ServerHook#fireOnServerStarted}
+     */
+    public static void serverStarted() {
+        try {
+            fPlayerConnection = Player.class.getDeclaredField("modConnection");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("Error initializing ModComm", e);
+        }
+    }
+
+    /**
+     * Player connected handler, called from {@link org.gotti.wurmunlimited.modloader.ServerHook#fireOnPlayerLogin}
+     */
+    public static void playerConnected(Player player) {
+        if (!channels.isEmpty())
+            player.getCommunicator().sendNormalServerMessage(ModCommConstants.BANNER);
+    }
+
+    // === Logging ===
+
+    static void logException(String msg, Throwable e) {
+        if (logger != null)
+            logger.log(Level.SEVERE, msg, e);
+    }
+
+    static void logWarning(String msg) {
+        if (logger != null)
+            logger.log(Level.WARNING, msg);
+    }
+
+    static void logInfo(String msg) {
+        if (logger != null)
+            logger.log(Level.INFO, msg);
+    }
+
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/ModCommConstants.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/ModCommConstants.java
@@ -1,0 +1,29 @@
+package org.gotti.wurmunlimited.modcomm;
+
+public class ModCommConstants {
+    /**
+     * Packet ID for all packets used by this system, should not collide with any packets used by WU (see {@link com.wurmonline.shared.constants.ProtoConstants})
+     */
+    public static final byte CMD_MODCOMM = -100;
+
+    /**
+     * Marker that will be detected by the client to initiate the handshake process
+     */
+    public static final String MARKER = "[ModCommV1]";
+
+    /**
+     * Human readable message that will be sent to connecting players
+     */
+    public static final String BANNER = MARKER + " This is a modded server, additional features might be available if you install Ago's Client Mod Launcher (http://forum.wurmonline.com/index.php?/topic/134945-/)";
+
+    /**
+     * Version of the internal protocol
+     */
+    public static final byte PROTO_VERSION = 1;
+
+    /**
+     * Packet types for the internal protocol
+     */
+    public static final byte PACKET_MESSAGE = 1;
+    public static final byte PACKET_CHANNELS = 2;
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/ModCommHandler.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/ModCommHandler.java
@@ -1,0 +1,89 @@
+package org.gotti.wurmunlimited.modcomm;
+
+import com.wurmonline.communication.SocketConnection;
+import com.wurmonline.server.players.Player;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+
+public class ModCommHandler {
+    public static void handlePacket(Player player, ByteBuffer msg) {
+        try {
+            byte type = msg.get();
+            switch (type) {
+                case ModCommConstants.PACKET_MESSAGE:
+                    handlePacketMessage(player, msg);
+                    break;
+                case ModCommConstants.PACKET_CHANNELS:
+                    handlePacketChannels(player, msg);
+                    break;
+                default:
+                    ModComm.logWarning(String.format("Unknown packet from player %s (%d)", player, type));
+            }
+        } catch (Exception e) {
+            ModComm.logException(String.format("Error handling packet from player %s", player.getName()), e);
+        }
+    }
+
+    private static void handlePacketChannels(Player player, ByteBuffer msg) throws IOException {
+        PacketReader reader = new PacketReader(msg);
+        HashSet<Channel> toActivate = new HashSet<>();
+
+        byte version = reader.readByte();
+        int n = reader.readInt();
+
+        ModComm.logInfo(String.format("Received client handshake from %s, %d channels, protocol version %d", player.getName(), n, version));
+
+        while (n-- > 0) {
+            String channel = reader.readUTF();
+            if (ModComm.channels.containsKey(channel))
+                toActivate.add(ModComm.channels.get(channel));
+        }
+
+        ModComm.logInfo(String.format("Activating %d channels for player %s", toActivate.size(), player.getName()));
+
+        ModComm.getPlayerConnection(player).activate(version, toActivate);
+
+        try (PacketWriter writer = new PacketWriter()) {
+            writer.writeByte(ModCommConstants.CMD_MODCOMM);
+            writer.writeByte(ModCommConstants.PACKET_CHANNELS);
+            writer.writeByte(ModCommConstants.PROTO_VERSION);
+            writer.writeInt(toActivate.size());
+            for (Channel channel : toActivate) {
+                writer.writeInt(channel.id);
+                writer.writeUTF(channel.name);
+            }
+            SocketConnection conn = player.getCommunicator().getConnection();
+            ByteBuffer buff = conn.getBuffer();
+            buff.put(writer.getBytes());
+            conn.flush();
+        }
+
+        for (Channel channel : toActivate) {
+            try {
+                channel.listener.onPlayerConnected(player);
+            } catch (Exception e) {
+                ModComm.logException(String.format("Error in channel %s onPlayerConnected", channel.name), e);
+            }
+        }
+    }
+
+    private static void handlePacketMessage(Player player, ByteBuffer msg) {
+        int id = msg.getInt();
+        if (!ModComm.idMap.containsKey(id)) {
+            ModComm.logWarning(String.format("Message on unregistered channel %d from player %s", id, player.getName()));
+            return;
+        }
+        Channel ch = ModComm.idMap.get(id);
+        if (!ch.isActiveForPlayer(player)) {
+            ModComm.logWarning(String.format("Message on inactive channel %s from player %s", ch.name, player.getName()));
+            return;
+        }
+        try {
+            ch.listener.handleMessage(player, msg.slice());
+        } catch (Exception e) {
+            ModComm.logException(String.format("Error in channel handler %s for player %s", ch.name, player.getName()), e);
+        }
+    }
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/PacketReader.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/PacketReader.java
@@ -1,0 +1,41 @@
+package org.gotti.wurmunlimited.modcomm;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Convenience class for reading packets, see {@link DataInputStream docs for the various reading methods}
+ */
+public class PacketReader extends DataInputStream {
+    private static class ByteBufferBackedInputStream extends InputStream {
+        private final ByteBuffer buf;
+
+        private ByteBufferBackedInputStream(ByteBuffer buf) {
+            this.buf = buf;
+        }
+
+        public int read() throws IOException {
+            if (buf.hasRemaining()) {
+                return buf.get() & 0xFF;
+            } else {
+                return -1;
+            }
+        }
+
+        public int read(byte[] bytes, int off, int len) throws IOException {
+            if (buf.hasRemaining()) {
+                len = Math.min(len, buf.remaining());
+                buf.get(bytes, off, len);
+                return len;
+            } else {
+                return -1;
+            }
+        }
+    }
+
+    public PacketReader(ByteBuffer buffer) {
+        super(new ByteBufferBackedInputStream(buffer));
+    }
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/PacketWriter.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/PacketWriter.java
@@ -1,0 +1,21 @@
+package org.gotti.wurmunlimited.modcomm;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Convenience class for writing packets, see {@link DataOutputStream docs for the various writing methods}
+ */
+public class PacketWriter extends DataOutputStream {
+    private final ByteArrayOutputStream buffer;
+
+    public PacketWriter() {
+        super(new ByteArrayOutputStream());
+        buffer = (ByteArrayOutputStream) out;
+    }
+
+    public ByteBuffer getBytes() {
+        return ByteBuffer.wrap(buffer.toByteArray(), 0, buffer.size());
+    }
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/PlayerModConnection.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/PlayerModConnection.java
@@ -1,0 +1,44 @@
+package org.gotti.wurmunlimited.modcomm;
+
+import java.util.Set;
+
+/**
+ * Connection information for a player
+ */
+public class PlayerModConnection {
+    private boolean active;
+    private byte version;
+    private Set<Channel> channels;
+
+    public PlayerModConnection() {
+        active = false;
+        version = -1;
+    }
+
+    void activate(byte version, Set<Channel> channels) {
+        this.active = true;
+        this.version = version;
+        this.channels = channels;
+    }
+
+    /**
+     * @return true if player has the client mod launcher loaded and can receive messages
+     */
+    public boolean isActive() {
+        return active;
+    }
+
+    /**
+     * @return protocol version supported by this player
+     */
+    public byte getVersion() {
+        return version;
+    }
+
+    /**
+     * @return set of channel ids active for this player
+     */
+    public Set<Channel> getChannels() {
+        return channels;
+    }
+}

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modloader/ModLoader.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modloader/ModLoader.java
@@ -24,6 +24,7 @@ import javassist.Loader;
 import javassist.NotFoundException;
 import javassist.Translator;
 
+import org.gotti.wurmunlimited.modcomm.ModComm;
 import org.gotti.wurmunlimited.modloader.classhooks.HookManager;
 import org.gotti.wurmunlimited.modloader.interfaces.Configurable;
 import org.gotti.wurmunlimited.modloader.interfaces.Initable;
@@ -83,6 +84,10 @@ public class ModLoader {
 				((Configurable) modEntry.mod).configure(modEntry.properties);
 				}
 			});
+
+		try (EarlyLoadingChecker c = initEarlyLoadingChecker("ModComm", "init")) {
+			ModComm.init();
+		}
 
 		mods.stream().filter(modEntry -> modEntry.mod instanceof PreInitable).forEach(modEntry -> {
 			try (EarlyLoadingChecker c = initEarlyLoadingChecker(modEntry.name, "preinit")) {

--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modloader/ServerHook.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modloader/ServerHook.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.gotti.wurmunlimited.modcomm.ModComm;
 import org.gotti.wurmunlimited.modloader.interfaces.ItemTemplatesCreatedListener;
 import org.gotti.wurmunlimited.modloader.interfaces.PlayerLoginListener;
 import org.gotti.wurmunlimited.modloader.interfaces.PlayerMessageListener;
@@ -26,6 +27,7 @@ public class ServerHook {
 	}
 	
 	public void fireOnServerStarted() {
+		ModComm.serverStarted();
 		for (WurmServerMod mod : mods) {
 			try {
 				if (mod instanceof ServerStartedListener) {
@@ -64,6 +66,7 @@ public class ServerHook {
 	}
 	
 	public void fireOnPlayerLogin(Player player) {
+		ModComm.playerConnected(player);
 		for (WurmServerMod mod : mods) {
 			try {
 				if (mod instanceof PlayerLoginListener) {


### PR DESCRIPTION
More or less what i described here: http://forum.wurmonline.com/index.php?/topic/133085-released-server-mod-loader-priest-crops-seasons-server-packs-bag-of-holding/&page=17#comment-1444175

I went with a packet based system, taking over packet id -100. Currently wurm uses all positive values, and the lowest used negative value is -52, so this seems like a safe bet from future expansion.

Channels are registered by mods on both client and server, using string identifiers. Numeric ids are assigned at runtime for more efficient communication. Messages between mods are sent as ByteBuffer's that can contain anything, a helper reader/writer class is provided for those that want an easier interface.

The handshake works like this:

* On client login, server sends an event message beggining with "[ModCommV1]" (the rest can be human readable for unmodded users).
* Client detects this message, hides it and sends a packet to the server with all registered channels.
* Server compares list of channels from the client to it's own and marks all shared channels as activated. Notifies mods. Sends a final list of channels, and their numeric IDs to the client.
* Client receives final list, marks channels as active and notifies mods.

A modded client logging into an unmodded server will see nothing, while an unmodded client logging into a modded server will see the human readable message with a link to the modloader thread, but otherwise will get no spam and can play normally.

I've changed the serverpacks mod to use the new system, and also @TysonCodes tooltip mod (the changes are [here](https://github.com/TysonCodes/WurmQualityDamageTooltips/compare/master...bdew-wurm:modcomm?expand=1) - will submit a PR to him once this is accepted).

Client side part here - ago1024/WurmClientModLauncher#6