### PR TITLE
modactions not working with tile borders and some other stuff due to private methods

### DIFF
--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modsupport/actions/ModActions.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modsupport/actions/ModActions.java
@@ -80,7 +80,7 @@ public class ModActions {
 			ctActionEntrys.setModifiers(Modifier.clear(ctActionEntrys.getModifiers(), Modifier.FINAL));
 			
 			CtClass ctBehaviourDispatcher  = classPool.get("com.wurmonline.server.behaviours.BehaviourDispatcher");
-			for (CtMethod method : ctBehaviourDispatcher.getMethods()) {
+			for (CtMethod method : ctBehaviourDispatcher.getDeclaredMethods()) {
 				method.instrument(new ExprEditor() {
 					@Override
 					public void edit(MethodCall m) throws CannotCompileException {


### PR DESCRIPTION
getMethods only returns non-private methods, and some of the methods in BehaviourDispatcher are private so they don't get correctly redirected to the ModActions code.