### PR TITLE
Fix bug with custom moves

### DIFF
--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modsupport/CreatureTemplateBuilder.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modsupport/CreatureTemplateBuilder.java
@@ -371,8 +371,11 @@ public class CreatureTemplateBuilder {
 				temp.setOnFire(onFire);
 				temp.setFireRadius(fireRadius);
 			}
+			
+			if (combatMoves != null) {
 			temp.setCombatMoves(combatMoves);
-
+			}
+			
 			return temp;
 		} catch (IOException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | ClassCastException | NoSuchFieldException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
Needed a null check in case people did not want to use custom moves, and to protect legacy creatures already modded.