### PR TITLE
Fix incorrect "The X will not leave the server." message for modded items if target server is not known

### DIFF
--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/intra/playertransfer/ModPlayerTransfer.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modcomm/intra/playertransfer/ModPlayerTransfer.java
@@ -252,7 +252,7 @@ public class ModPlayerTransfer {
 	public boolean willItemLeaveServer(int targetServer, Item item, boolean setTransferFlag) {
 		TemplateIdMapper itemTemplateMapper = getItemTemplateMapper(targetServer);
 		int templateId = item.getTemplateId();
-		boolean result = TemplateIdMapper.isRegularTemplate(IdType.ITEMTEMPLATE, templateId) || itemTemplateMapper != null && itemTemplateMapper.willTemplateLeaveServer(templateId);
+		boolean result = TemplateIdMapper.isRegularTemplate(IdType.ITEMTEMPLATE, templateId) || (targetServer == 0) ||(itemTemplateMapper != null && itemTemplateMapper.willTemplateLeaveServer(templateId));
 		if (setTransferFlag && !result) {
 			// Mark the item as not transferable. Yes, "true" is correct
 			item.setTransferred(true);


### PR DESCRIPTION
Communicator.checkLegalTileMove is calling PlayerTransfer.willItemsTransfer with targetServer=0, which means there is no mapping for the server and ModPlayerTransfer.willItemLeaveServer returns false.
 
This only seems to affect checks as the player is approaching a border, which causes a bunch of incorrect "The X will not leave the server." messages but doesn't affect the actual transfers.

I've made willItemLeaveServer return true if server id = 0 to prevent those incorrect messages.