### PR TITLE
Add an option to allow BoH to apply to components in items

### DIFF
--- a/modules/mods/bagofholding/src/dist/bagofholding.config
+++ b/modules/mods/bagofholding/src/dist/bagofholding.config
@@ -10,3 +10,5 @@
 # any other number: quadratic progression up to effectModifier additional volume
 # An effectModifier of 10 will give 2.5 times additional volume for a 50 cast and 10 times additional volume for a 100 cast.
 #effectModifier=10
+# allowComponentItems: Allows bag of holding to apply to components of an item it's cast on (e.g. Bulk container units)
+#allowComponentItems=false

--- a/modules/mods/bagofholding/src/main/java/org/gotti/wurmunlimited/mods/bagofholding/BagOfHoldingMod.java
+++ b/modules/mods/bagofholding/src/main/java/org/gotti/wurmunlimited/mods/bagofholding/BagOfHoldingMod.java
@@ -45,6 +45,7 @@ public class BagOfHoldingMod implements WurmServerMod, Initable, PreInitable, Co
 	private int spellDifficulty = 20;
 	private long spellCooldown = 300000L;
 	private int effectModifier = 0;
+	private boolean allowComponentItems;
 	
 	private static final Logger logger = Logger.getLogger(BagOfHoldingMod.class.getName());
 	
@@ -77,11 +78,13 @@ public class BagOfHoldingMod implements WurmServerMod, Initable, PreInitable, Co
 		spellDifficulty = Integer.valueOf(properties.getProperty("spellDifficulty", Integer.toString(spellDifficulty)));
 		spellCooldown = Long.valueOf(properties.getProperty("spellCooldown", Long.toString(spellCooldown)));
 		effectModifier = Integer.valueOf(properties.getProperty("effectModifier", Integer.toString(effectModifier)));
+		allowComponentItems = Boolean.parseBoolean(properties.getProperty("allowComponentItems", "false"));
 		
 		logger.log(Level.INFO, "spellCost: " + spellCost);
 		logger.log(Level.INFO, "spellDifficulty: " + spellDifficulty);
 		logger.log(Level.INFO, "spellCooldown: " + spellCooldown);
 		logger.log(Level.INFO, "effectModifier: " + effectModifier);
+		logger.log(Level.INFO, "allowComponentItems: " + allowComponentItems);
 	}
 	
 	@Override
@@ -163,6 +166,12 @@ public class BagOfHoldingMod implements WurmServerMod, Initable, PreInitable, Co
 							Item target = (Item)proxy;
 							
 							float modifier = BagOfHolding.getSpellEffect(target);
+
+							if (allowComponentItems && target.isComponentItem()) {
+								Item parent = target.getParentOrNull();
+								if (parent != null && BagOfHolding.isValidTarget(parent))
+									modifier = BagOfHolding.getSpellEffect(parent);
+							}
 							
 							if (effectModifier == 0) {
 								if (modifier > 1) {


### PR DESCRIPTION
BoH is currently useless items with internal components like e.g. bulk storage units, or stills because it does nothing when you cast it on the top level item and you can't cast it on the internal parts.

This change adds an new option that if enabled makes volume checks on internal parts instead take the BoH cast from their parent.