### PR TITLE
Fix for serverpacks sometimes leaving VisionArea in buggy state after refresh

### DIFF
--- a/modules/mods/serverpacks/src/main/java/org/gotti/wurmunlimited/mods/serverpacks/CommandHandler.java
+++ b/modules/mods/serverpacks/src/main/java/org/gotti/wurmunlimited/mods/serverpacks/CommandHandler.java
@@ -1,0 +1,21 @@
+package org.gotti.wurmunlimited.mods.serverpacks;
+
+import com.wurmonline.server.Server;
+import com.wurmonline.server.players.Player;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class CommandHandler {
+    private static Logger logger = Logger.getLogger(ServerPackMod.class.getName());
+
+    static void sendModelRefresh(Player player) {
+        try {
+            player.createVisionArea();
+            Server.getInstance().addCreatureToPort(player);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, e.getMessage(), e);
+        }
+    }
+
+}

--- a/modules/mods/serverpacks/src/main/java/org/gotti/wurmunlimited/mods/serverpacks/ServerPackMod.java
+++ b/modules/mods/serverpacks/src/main/java/org/gotti/wurmunlimited/mods/serverpacks/ServerPackMod.java
@@ -98,7 +98,7 @@ public class ServerPackMod implements WurmServerMod, ModListener, Initable, Conf
 					byte cmd = reader.readByte();
 					switch (cmd) {
 					case CMD_REFRESH:
-						sendModelRefresh(player);
+						CommandHandler.sendModelRefresh(player);
 						break;
 					default:
 						logger.log(Level.WARNING, String.format("Unknown channel command 0x%02x", 128 + cmd));
@@ -109,14 +109,6 @@ public class ServerPackMod implements WurmServerMod, ModListener, Initable, Conf
 				}
 			}
 		});
-	}
-
-	private void sendModelRefresh(Player player) {
-		try {
-			player.createVisionArea();
-		} catch (Exception e) {
-			logger.log(Level.WARNING, e.getMessage(), e);
-		}
 	}
 
 	@Override


### PR DESCRIPTION
This fixes a bug happens when a refresh command is sent after a players VisionArea is already fully initialized.

When this happens the player will not be able to use gm teleport wands, and minedoors will stop opening for them. This also produces messages like that in the log:

> Auriel could not teleport due to VisionArea VisionArea [initialised: false, resumed: false, sentCloseStrips: false, sentFarStrips: false]

(note all flags being false, it will stay like that until the player relogs)

I've also moved the method to a separate class as with my addition it was causing a bunch of classes to be frozen when the mod class was loaded.