### PR TITLE
fix horses getting stuck in zones, and throwing errors in the log

### DIFF
--- a/modules/demo/hitchingpost/src/main/java/org/gotti/wurmunlimited/mods/hitchingpost/UnhitchAction.java
+++ b/modules/demo/hitchingpost/src/main/java/org/gotti/wurmunlimited/mods/hitchingpost/UnhitchAction.java
@@ -76,6 +76,12 @@ public class UnhitchAction implements BehaviourProvider, ActionPerformer {
 	public boolean action(Action action, Creature performer, Creature target, short num, float counter) {
 		if (canUnhitch(performer, target)) {
 			final Vehicle hitched = target.getHitched();
+			if (!hitched.positionDragger(target, performer)) {
+				performer.getCommunicator().sendNormalServerMessage("You can't unhitch the " + target.getName() + ". Please contact an administrator.");
+				logger.warning(performer.getName()+" was not able to unhitch the "+target.getName()+" from a hitching post at "+target.getTileX()+","+target.getTileY());
+				return propagate(action);
+			}
+			
 			try {
 				final Zone z = Zones.getZone(target.getTilePos(), target.isOnSurface());
 				target.getStatus().savePosition(target.getWurmId(), true, z.getId(), true);


### PR DESCRIPTION
On my server and test server the hitching post mod kept breaking horses and throwing errors as such:
```
[05:14:05 DU] WARNING com.wurmonline.server.creatures.Creature: old horse set to 2351,2741 but at 2352,2741
java.lang.Exception
	at com.wurmonline.server.creatures.Creature.setNewTile(Creature.java:843)
	at com.wurmonline.server.zones.VolaTile.addCreature(VolaTile.java:1847)
	at com.wurmonline.server.zones.VolaTile.creatureMoved(VolaTile.java:2889)
	at com.wurmonline.server.zones.VolaTile.creatureMoved(VolaTile.java:2725)
	at com.wurmonline.server.creatures.Creature.moved(Creature.java:12575)
	at com.wurmonline.server.creatures.Creature.followLeader(Creature.java:12182)
	at com.wurmonline.server.creatures.Creature.creatureMoved(Creature.java:5190)
	at com.wurmonline.server.zones.VirtualZone.creatureMoved(VirtualZone.java:1728)
	at com.wurmonline.server.zones.VolaTile.creatureMoved(VolaTile.java:2939)
	at com.wurmonline.server.zones.VolaTile.creatureMoved(VolaTile.java:2725)
	at com.wurmonline.server.creatures.Creature.moved(Creature.java:12551)
	at com.wurmonline.server.creatures.Communicator.movePlayer(Communicator.java:864)
	at com.wurmonline.server.creatures.Communicator.pollNextMove(Communicator.java:1063)
	at com.wurmonline.server.Server.pollComms(Server.java:2664)
	at com.wurmonline.server.Server.run(Server.java:2542)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
```

If you find you can reproduce the issue, my commit fixes it. 


I looked at what the original unhitching action does and it called the function `hitched.positionDragger()`, which tinkers with the position and can indicate that something's wrong.

I've yet to actually get the error message in the new `if()`. The fix works without hindering players' ability to unhitch the creature.